### PR TITLE
Hmm, just noticed that I can collect comments in the commit window on

### DIFF
--- a/Doc/GH/Paris2/WeAgree/03_Joint-Development/Form/0.md
+++ b/Doc/GH/Paris2/WeAgree/03_Joint-Development/Form/0.md
@@ -1,0 +1,610 @@
+
+This Joint Development Agreement (the Agreement) is entered into on 24 January 2014, 
+
+Doc.Ti= Joint Development Agreement
+
+Why.1.sec=(A)	Weagree accelerates contract drafting by providing contract assembly software (the Weagree Wizard) combined with model contract upgrading services.
+
+Why.2.sec=(B)	Partner 1 is active in the field of [______]. 
+
+Why.3.sec=(C)	Partner 2 has broad experience in the business of [_____].
+
+Why.4.sec=(D)	The Parties desire to cooperate and jointly undertake the Project (capitalised terms are defined in Article 20).
+
+Note=Where should this go?
+
+Capitalised terms used in this Agreement are defined in Article 20.
+
+Note=Different structure than other docs - the "Chapter" notion.
+
+CHAPTER I.	PROJECT AND PROJECT EXECUTION
+
+1.Ti=SCOPE OF THE AGREEMENT
+
+1.1.Ti=Project
+
+1.1.sec=The Parties hereby undertake with each other to complete the Project in accordance with the Project Description and this Agreement.
+
+1.2.Ti=Guiding principles. This Agreement and the decisions by the Parties shall be governed by the following principles:
+
+1.2.1.sec=win-win. Each Party shall benefit from the Project, both in the short term and in the longer term future.
+
+1.2.2.sec=reasonable assistance and cooperation. Each Party shall cooperate and provide the other Party promptly with such assistance as that Party may reasonably require in respect of a work package, a part of the [Work] or its obligations in connection with the completion of the Project.
+
+1.2.3.sec=openness. Without prejudice to any provision in this Agreement, the Parties shall exercise openness vis-à-vis each other in respect of the subject matters of the Project and shall keep each other informed of circumstances that can be assumed reasonably to be of importance in respect of the feasibility, objectives or completion of the Project.
+
+1.2.00.sec=The Parties undertake to contact each other regularly to discuss the progress of the Project and any related results or problems. After each Milestone, representatives of each Party shall meet to discuss the results achieved at such Milestone.
+
+1.3.Ti=Provision of materials
+
+1.3.sec=Each Party shall provide the other Party with all necessary materials, documents, necessary data and other information relating to the Project, in such timely fashion as to enable that Party’s performance in accordance with the Agreement.
+
+1.4.Ti=Time of the essence
+
+1.4.sec=All dates specified in the Time Schedule are of the essence, unless the context clearly permits otherwise. Each Party shall inform the other Party promptly of any circumstances that may cause any delay, specifying the reasons of any delay and expected duration, as well as any proposed measures to reduce any delay as much as practicable. Any delay in meeting the Time Schedule requires the prior approval of that other Party in writing, which approval shall not unreasonably be withheld.
+
+1.5.Ti=Specifications and timing
+
+1.5.sec=Insofar as is reasonably practicable, each Party shall provide the Services in accordance with the Time Schedule in the Project Description and, failing such Time Schedule, at such times and in such timely fashion as Parties may decide.
+
+1.6.Ti=Service level
+
+1.6.sec=In performing its obligations under this Agreement, each Party shall ensure that its required employees make reasonable efforts and perform their duties and obligations with due care, in a professional and ethical manner and in accordance with guidelines agreed by the Parties from time to time. Unless the Parties determine otherwise from time to time, each of the Parties shall assign at least [__] persons (being at least x.0 FTE per Party) to the Project.
+
+2.Ti=CHANGES OF THE PROJECT SCOPE OR SPECIFICATIONS
+
+2.1.Ti=Detailing of the Specifications
+
+2.1.sec=Each Party shall be entitled to further specify or detail the Specifications in writing, as it deems necessary or desirable, provided that it does not affect any agreed service fees or the Time Schedule. The Parties shall implement all such further specifications and detailing, except that if the specification or detailing results in a modification of work already completed by a Party in accordance with its internal planning, the costs of such modification shall be for the account of the Party that provided such further specification or detailing. To the extent that such further specification or detailing affects the Time Schedule, the Parties so affected shall be entitled to postpone the delivery date to such later date as necessitated by their planning capabilities.
+
+2.2.Ti=Change of Specifications
+
+2.2.sec=Each Party shall be entitled to amend the Specifications (the Proposing Party) prior to delivery of the Milestones or Work to which such amendment pertains, provided that such an amendment is specific as regards the impact on the Specifications (a Change Request), indicating as much as reasonably possible the consequences regarding form, fit, function and use, the implementation and any related cost effects. After receipt of a Change Request, the other Party (the Adopting Party) shall inform the Proposing Party of the anticipated impact on the Time Schedule and the estimated extra costs of the Change Request (a Change Impact Notice). To the extent that the Change Request is not specific about the impact on the Specifications, the Adopting Party shall be free to interpret the Change Request as it deems appropriate (and the Proposing Party shall not be entitled to withhold acceptance of the Milestones or Work on the basis of such failing specification).
+
+2.3.Ti=Subsequent action
+
+2.3.sec=After receipt of the Change Impact Report, the Adopting Party shall notify the Proposing Party as soon as practicable whether it approves the Change Impact Notice. Upon the Adopting Party’s approval, the Specifications and the Time Schedule shall be deemed to be amended according to the Change Impact Notice. A Change Request shall not be implemented prior to the Adopting Party’s written approval.
+
+2.4.Ti=Dispute settlement
+
+2.4.sec=If the Parties disagree (a) whether further specification or detailing of the Specification constitutes a modification of the Specifications, or (b) about the consequences of a Change Request or a Change Impact Report, the Parties shall first attempt to achieve an amicable solution. Failing a satisfactory solution, each Party shall be entitled to invoke the dispute settlement provisions applicable in case of disputes regarding non-acceptance. The findings of the expert shall be binding upon the Parties.
+
+3.Ti=SUBCONTRACTING
+
+3.1.Ti=No subcontracting
+
+3.1.sec=No Party shall subcontract or delegate any part of its obligations under this Agreement to a third party, except to its Affiliates, without the prior written consent of the other Party. A consent shall not release the subcontracting Party from any obligation or liability pursuant to this Agreement.
+
+3.2.Ti=Obligations subcontractors
+
+3.2.sec=Each Party shall bind its current and any future subcontractors and other second-tier suppliers to at least similar terms and conditions as are applicable to itself under this Agreement with regard to the subcontracted part of its performance and shall procure that those Parties comply with these terms and conditions, including (as applicable) with respect to quality, environment, safety and health, as well as regards assignment and licensing of Intellectual Property. Upon either Party’s request, Parties shall provide documentation sufficient to confirm that they have complied with this Agreement.
+
+3.3.Ti=Monitoring and auditing rights
+
+3.3.sec=Notwithstanding Section 3.1, a Party shall at all times be entitled to monitor and audit each subcontracted obligation of the other Party. Upon first request, such other Party shall facilitate direct technical discussions with such subcontractors.
+
+3.4.Ti=Reporting on subcontractors
+
+3.4.sec=Annually, the Parties shall report how their key suppliers and subcontractors have performed in the preceding year with respect to quality, environment, safety and health. The Parties shall agree on the reporting format and requirements.
+
+4.Ti=DELIVERY AND ACCEPTANCE TESTING
+
+4.1.Ti=Acceptance required
+
+4.1.sec=Except as otherwise agreed, the completion of each Milestone and the [Work] delivered by one Party (the Delivering Party) is subject to acceptance by the other Party (the Accepting Party) in accordance with this Article 4.
+
+4.2.Ti=Incoming inspection and tests
+
+4.2.sec=Upon delivery, the Accepting Party shall inspect and test the Milestones or [Work], exercising such care as is customary or appropriate in the circumstances and satisfy itself that the Milestones or [Work], as the case may be, meets the Specifications.
+
+4.3.Ti=Acceptance
+
+4.3.sec=Complaints about the Milestones or [Work] shall be made in writing and must be received by the Delivering Party not later than five working days from the date of delivery in respect of any defect, non-conformity or shortage that would be apparent from a quick scan inspection, or 30 days from the date of delivery in respect of all other defect or non-conformity to the Specifications. Except to the extent required for testing purposes, the use or processing of Milestones or  the [Work] shall be deemed to be an unconditional acceptance of the Milestones or [Work] and a waiver of all claims in respect of such Milestones or [Work]. If no notice of defects or non-conformity to the Specifications has been received by the Delivering Party within the above period of time, the Milestones or [Work], as the case may be, shall be deemed to be accepted by the Delivering Party.
+
+4.4.Ti=Method of testing and analysis
+
+4.4.sec=The Accepting Party shall test in accordance with the Acceptance Tests and furthermore as specified in the Project Description. Failing any specified method of testing in the Project Description, the determination whether the Milestones or [Work] conform to the Specifications shall be done solely by analysing the samples or records retained by the Delivering Party and taken from the batches or production runs in which the Milestone or [Work] was produced in accordance with the methods of analysis applied by the Delivering Party.
+
+4.5.Ti=Insignificant non-conformity
+
+4.5.sec=A defect or non-conformity in parts of the Milestones or [Work] does not entitle the Accepting Party to reject the delivery of the Milestones or [Work] entirely.
+
+4.6.Ti=Ownership
+
+4.6.sec=All ownership rights to any part of the Milestones or [Work] shall vest in the Party (or its Affiliate) that according to Article 10 is to be the owner from the date of creation, regardless of whether the Milestones or [Work] be actually delivered by the Delivering Party.
+
+5.Ti=RESTRICTIVE COVENANTS
+
+5.1.Ti=Exclusivity
+
+5.1.1.sec=Until one year after the date of completion of the Project and a termination of this Agreement, no Party shall, directly or indirectly, for own benefit or for the benefit of third parties, undertake activities or facilitate any activities in the [Partner 1 Field of Use], and no Party shall, directly or indirectly, for own benefit or for the benefit of third parties, undertake activities or facilitate any activities in [Partner 2 Field of Use].
+
+5.1.2.sec=For the purpose of this Section 5.1, undertaking activities include (i) any investment (or option to invest), consultancy or advisory work, any representation, in any manner, directly or indirectly, whether in a professional, informal or personal context or otherwise, in such field of business, and (ii) any of the aforementioned activities for any customer or supplier of that Party.
+
+5.1.3.sec=If this Section 5.1 would become invalid for any reason at any point in time (other than the lapse of the period provided in the first sentence), the Parties undertake with each other to agree to amend this Section to the greatest extent permitted by the applicable law.
+
+Note=some unnumbered paragraphs.  Maybe better to make them numbered like the others??
+
+5.1.=[Z/paras/s3]
+
+5.2.Ti=Non-solicitation
+
+5.2.1.sec=No Party shall, until one year after the date of this Agreement, directly or indirectly, solicit or endeavour to entice away, any of the other Party’s Key Managers with whom such Party (or an employee of such Party) has come into contact during the negotiations or discussions in relation to the Project; provided, however, that a Party shall not be precluded or otherwise restricted from hiring or employing, or from having employment or hiring discussions with, any such person (a) who is not then employed by that other Party, (b) who contacts it without any solicitation by it, or (c) who responds to a general solicitation for employment placed by it or its agents in newspapers, trade journals, the internet, through recruiters or by any media; and furthermore that any such generic solicitation shall not constitute a breach of this Agreement.
+
+5.2.2.sec=For the purpose of this Section 5.2, a Key Manager means any director, officer or senior employee in a key capacity of a Party or an Affiliate of it and any of their employees in a key position in view of the Project, at any time between the date of this Agreement and the date on which discussions relating to the Project are terminated or completion of a transaction as part of the Project, as the case may be.
+
+Note=some unnumbered paragraphs.  Maybe better to make them numbered like the others??
+
+CHAPTER II.	PROJECT ORGANISATION
+
+6.Ti=KEY PERSONS CARRYING OUT THE PROJECT
+
+6.1.Ti=Highly qualified personnel
+
+6.1.sec=Each Party shall ascertain that it is at all times during a Project able to provide the required technology competences and have adequately qualified, experienced and capable persons available as required from it for completing the applicable Project. Subject to Section 6.2, each Party shall in any event involve the employees named in the Project Description (Key People) and ensure that such work and those obligations are carried out by those Key People.
+
+6.2.Ti=Freedom to operate and Foreground IPR
+
+6.2.sec=A Party shall not involve an employee in any part of the work or any obligation under this Agreement if that person has not expressly agreed to such an employment arrangement that that Party (in its capacity of employer) is entitled to and may freely dispose of all Intellectual Property Rights developed by that employee in the course of the employment duties.
+
+6.3.Ti=Replacing personnel
+
+6.3.sec=An employee of either Party other than the Key People is permitted to carry out any part of the work or any obligations under this Agreement after having obtained written approval from the other Party. Parties shall not withhold such approval unreasonably. Each Party shall inform the other Party of the identity and background of any replacements for any of the Key People as soon as reasonably practicable. Each Party shall be entitled to interview any such person and may object to any such proposed appointment if it reasonably considers the proposed person to be unsuitable.
+
+[Note that in Weagree’s Model services agreement, the ‘project’ is organised around a steering committee, not individual Project Coordinators.]
+
+7.Ti=PROJECT COORDINATOR
+
+7.0.sec=Each Party shall appoint one person for coordinating the Project on its behalf (each, a Project Coordinator). The Project Coordinator shall be responsible for:
+
+7.1.sec=coordinating the Project on behalf of the appointing Party;
+
+7.2.sec=exchanging information between the Parties on the Project;
+
+7.3.sec=taking and communicating decisions in relation to the Project;
+
+7.4.sec=keeping accurate records of all relevant findings, results, acts and things done by the appointing Party in relation to the Project;
+
+7.5.sec=meeting regularly with the other Party’s Project Coordinator to review progress of any part of the Project; and
+
+7.6.sec=reporting, evaluating and giving adequate follow-up on reports and evaluations as provided in Article 9.
+
+
+8.Ti=PROJECT COMMITTEES AND WORKING GROUPS
+
+8.1.Ti=Project Committee
+
+8.1.sec=The Parties hereby establish a Project committee composed of representatives of each Party for conducting an overall supervision of the Parties’ performance and the direction of the Project, as well as any matters that the Parties have delegated to such committee from time to time for their decision (the Project Committee).
+
+8.2.Ti=Power and authority
+
+8.2.sec=The representative of each Party shall be authorised to represent and bind that Party with respect to any matter within the powers of the Project Committee. Each representative shall have one vote.
+
+8.3.Ti=Update meetings
+
+8.3.sec=The Parties shall meet monthly to discuss the progress of the Project.
+
+8.4.Ti=Working Groups
+
+8.4.0.sec=Parts of the Project may be conducted through one or more working groups consisting of employees of each Party (each, a Working Group). Each Working Group shall be responsible for completing a work package and delivering the Milestones and part of the [Work] as defined in connection with such work package. The Project Committee shall determine:
+
+8.4.1.sec=the precise contents and scope of each work package; and
+
+8.4.2.sec=the Time Schedule for completion of each work package and for delivering Milestones and parts of the [Work], in any event in accordance with the Time Schedule.
+
+8.5.Ti=Replacements
+
+8.5.sec=The replacement of a Party’s member of a Working Group by another employee requires the prior notification in writing to the other Party’s representative within the Project Committee. The Working Groups shall be responsible for carrying out the Project and shall report to the Project Committee on the progress of their work on a regular basis and as requested by the Project Committee.
+
+9.Ti=REPORTING AND EVALUATION
+
+9.1.Ti=Continuous reporting
+
+9.1.sec=The Parties undertake to contact each other regularly to discuss the progress of any of the Milestones and any results of or problems related to the [Work]. After every Milestone, representatives of each Party shall meet to discuss the results achieved at such Milestone. Ultimately two weeks before every such meeting, each Party shall provide the other Party with a summary in writing of the status of each Milestone and the results obtained.
+
+9.2.Ti=Completion report
+
+9.2.sec=Within four weeks after completion of all Milestones or [Work] or after termination of the Agreement, each Party shall submit a final written report to the other Party including a detailed description of the activities performed and the results obtained by it.
+
+9.3.Ti=Annual evaluation
+
+9.3.sec=At least once per year, and as often as a Party may request, the Parties shall convene a review meeting in order to discuss each Party’s performance under this Agreement and its performance in general and any other issue as reasonably requested by the other Party.
+
+9.4.Ti=Quality audits
+
+9.4.sec=Each Party may at least once per year perform or have performed an audit of the quality, environment, safety and health systems of the other Party. That Party shall make best efforts to make the audit effective and shall provide the auditing Party and its representatives, all reasonable assistance and access to its facilities, officers, employees and books and records.
+
+CHAPTER III.	INTELLECTUAL PROPERTY RIGHTS
+
+10.Ti=INTELLECTUAL PROPERTY
+
+10.1.Ti=Project license
+
+10.1.sec=Each Party hereby grants the other Party (and, accordingly, that other Party hereby accepts) a worldwide, non-exclusive, royalty-free license, with the right to sublicense to its Affiliates, under its Background IPR to make, have made, use, import, analyse, test, prepare derivative works of, reproduce, have reproduced such Background IPR for the purpose of performing its obligations in connection with the Project only.
+
+[OPTION 1 – address in Project Description: 
+
+10.Alt1.1.Sec={10.1.Sec}
+
+10.Alt1.2.Ti=General principle. The Intellectual Property Rights related to a Milestone and any part of the Project, including to all development data, reports and other technical information, shall be owned and licensed as provided in the Project Description.
+
+10.Alt1.=[Z/ol/2]
+
+[OPTION 2 – provide for joint ownership (note that this may turn out to be a complicated way of arranging Foreground IPR):
+
+10.Alt2.1.Sec={10.1.Sec}
+
+10.Alt2.2.Ti=Background IPR. The ownership of all Background IPR shall remain solely and exclusively with the Party owning such Background IPR or its third party suppliers, as the case may be.
+
+10.Alt2.3.Ti=Foreground IPR. Without prejudice to any other Section of this Article 10, the ownership of the Foreground IPR shall vest in the Party that has created such Foreground IPR. 
+
+10.Alt2.4.Ti=Joint creation. If a Party is of the opinion that the Parties have created Foreground IPR jointly, it shall notify the other Party in writing within 30 days of the creation. Foreground IPR shall be deemed to be created jointly if each Party (a) has made joint and reasonably similar efforts, [Optional: substantially] contributing to its creation, (b) such contribution forms an indivisible part of the created Foreground IPR[Optional: , and (c) such Foreground IPR cannot be identified as the Foreground IPR of one Party].
+
+10.Alt2.5.Ti=Joint IPR. Subject to the confirmation by each Party, in accordance with Section 10.4, that Foreground IPR has been created by the Parties jointly, the ownership of such Foreground IPR shall be joint and each joint owner shall have an equal, undivided interest in such jointly owned Foreground IPR in all jurisdictions worldwide. 
+
+10.Alt2.=[Z/ol/5]
+
+10.=[Z/Alt/2]
+
+11.Ti=MANAGEMENT OF JOINT PATENTS
+
+11.1.Ti=Exploitation of joint IPR
+
+11.1.0.sec=The following shall apply in respect of the filing, discontinuation and maintenance of registrations (including Patents) of jointly created Foreground IPR in any jurisdiction:
+
+11.1.1.sec=Upon the confirmation by each Party, the Parties shall agree on (i) an appropriate course of action for filing applications for registering or not of such Foreground IPR, (ii) which Party shall prepare, file and prosecute such applications, and (iii) in which jurisdictions such applications for Foreground IPR are to be filed. Except for any priority applications, the filing of any applications for jointly owned Foreground IPR shall require mutual agreement between the Parties. All costs related to applications for jointly owned Foreground IPR and Intellectual Property Rights resulting from such Foreground IPR shall be shared equally between the Parties. 
+
+11.1.2.sec=If one of the Parties confirms in writing that it is not interested in filing any application for a jointly owned Foreground IPR (an Uninterested Party), upon first request of the other Party, that Uninterested Party shall assign its rights in such Foreground IPR to the other Party and the other Party shall be entitled to file or have filed such application in its own name and at its own expense. Accordingly, that other Party shall be the sole owner of such Foreground IPR, subject to a non-transferable, non-exclusive, royalty-free license, without the right to grant sub-licenses, for the lifetime of such Foreground IPR to the benefit of, and for the use by, the Uninterested Party.
+
+11.1.3.sec=If one of the Parties wishes to file an application for Foreground IPR in a jurisdiction in which the other Party does not wish to file in its own name (an Applicant Party), the Applicant Party shall be entitled to file or have filed such application in such jurisdiction in its own name and at its own expense. Accordingly, the Applicant Party shall be the sole owner of the Foreground IPR subject to a non-transferable, non-exclusive, royalty-free license, without the right to grant sub-licenses, for the lifetime of the Foreground IPR in the jurisdiction concerned for the benefit of, and the use by, the Party that was not interested in filing such application in such jurisdiction. 
+
+11.1.4.sec=If one of the joint owners of any Foreground IPR or an application for any Foreground IPR wishes to discontinue its share in the maintenance fees and other costs in one or more jurisdiction (a Discontinuing Party), it shall so notify the other Party. If the other Party wishes to continue such registration or application of any part of such Foreground IPR in such jurisdiction, it shall take over the payment of such share and the Discontinuing Party shall assign its rights in such jointly owned Foreground IPR for the jurisdictions concerned to that other Party, subject to the retention of a non-transferable, non-exclusive, royalty-free license, without the right to grant sub-licenses, for the lifetime of the Foreground IPR in those jurisdictions for the benefit of, and the use by, the Discontinuing Party. Upon such assignment, the Discontinuing Party ceases to have the right to grant licenses to third parties under such Foreground IPR for the jurisdictions concerned, except that the discontinuation of such right to grant licenses does not affect any licenses previously granted to third parties under such Foreground IPR.
+
+11.2.sec=Except as otherwise provided in Section 10.6, and without the consent of and without accounting to the other owner being required, each of the joint owners of Foreground IPR shall have the non-transferable right to (a) make, have made, modify, have modified, use, sell or otherwise dispose of any jointly owned Foreground IPR, and (b) grant non-exclusive licenses under any jointly owned Foreground IPR, provided that the owner granting such license fulfils its obligation, if any, to pay its share of the costs related to such Foreground IPR.
+
+11.3.sec=Actions for infringement. Each joint owner shall have the right to bring an action for infringement of any jointly owned Foreground IPR only with the prior written consent of the other joint owner. Such consent shall not be unduly delayed and may be withheld only if the infringement action would prejudice the other owner’s commercial interests as can be demonstrated to the reasonable satisfaction of the joint owner wishing to bring such infringement action.
+
+11.4.sec=Subject to the rights and obligations of each Party pursuant to this Article 11, each of the joint owners has the right to assign its rights under any jointly owned Foreground IPR to an acquirer of the joint owner’s business to which the jointly owned Foreground IPR pertains, as part of a divestiture carried out at an arm’s length basis.
+
+12.Ti=CONFIDENTIALITY
+
+12.1.Ti=Definition
+
+12.1.sec=In this Article 12, Confidential Information means any information of a non-public, confidential or proprietary nature, whether of commercial, financial or technical nature, customer, supplier, product or production-related or otherwise, including samples, information relating to raw materials, formulae, specifications, software, patent applications, process designs, process models, materials and ideas, disclosed by a Party (the Disclosing Party) to the other Party (the Receiving Party). Such information may be disclosed in any form, provided that it is disclosed reasonably in connection with this Agreement.
+
+12.2.Ti=Disclosure
+
+12.2.sec=A Disclosing Party may furnish Confidential Information to a Receiving Party as it deems necessary or helpful in relation to the Receiving Party's performance in relation to this Agreement. The Disclosing Party shall use its best efforts to mark Confidential Information which is disclosed in writing as being confidential. Failure to do so, however, shall leave the Receiving Party's obligations set forth in this Agreement unaffected. Information that was not identified as confidential or proprietary shall be treated as Confidential Information upon a written notice to the Receiving Party within 30 days from disclosure. 
+
+12.3.Ti=General
+
+12.3.sec=A Receiving Party shall not use Confidential Information for purposes other than in direct relation with this Agreement. The Receiving Party shall treat the Disclosing Party's Confidential Information with at least the same degree of care as it would use in respect of its own confidential information of similar importance, but in any event a reasonable level of care. A Receiving Party shall handle, test, use and keep the Disclosing Party's Confidential Information in conformity with all applicable legal requirements (if applicable). Except as provided otherwise, the Receiving Party shall not disclose, publish, disseminate or make accessible any part of the Disclosing Party’s Confidential Information, in any way or form, to anyone.
+
+12.4.Ti=Limited use
+
+12.4.sec=The Receiving Party shall not disclose, publish, disseminate or make accessible the Disclosing Party's Confidential Information, in whole or in part, in any way or form, to third parties. In particular, the Receiving Party shall disclose Confidential Information to its Affiliates, directors, officers, employees or other representatives only on a need-to-know basis. Prior to the disclosure of the Disclosing Party's Confidential Information to such persons, the Receiving Party shall inform each such person of the confidential nature of the Confidential Information and shall require that the person expressly agrees to treat the Confidential Information as is provided in this Agreement. Notwithstanding due observance of these requirements, the Receiving Party shall be liable for any breach of this Agreement by such person.
+
+12.5.Ti=Exemptions
+
+12.5.0.sec=The restrictions and obligations in this Article 12 shall not apply to the Disclosing Party’s Confidential Information, which: 
+
+12.5.1.sec=is or becomes generally available to the public other than as a result of a disclosure by the Receiving Party (or its representatives);
+
+12.5.2.sec=was received by the Receiving Party from a third party and not indirectly from the Disclosing Party in violation of any obligation of secrecy or non-use; or
+
+12.5.3.sec=was in the possession of the Receiving Party prior to disclosure or is developed independent from such Confidential Information, as is shown by competent evidence.
+
+12.6.Ti=Court orders
+
+12.6.sec=In case Confidential Information is required to be disclosed by the Receiving Party by virtue of a court order or statutory duty, the Receiving Party shall be allowed to do so, provided that it shall without delay inform the Disclosing Party in writing of receipt of such order or duty and enable the Disclosing Party reasonably to seek protection against such order or duty. 
+
+12.7.Ti=Delete or destroy
+
+12.7.sec=Upon the first request of a Disclosing Party, the Receiving Party shall without delay (a) return all their copies, samples and extracts of, and all other physical media containing, the Disclosing Party’s Confidential Information, and (b) delete or destroy (and have deleted or destroyed) all automated data containing the Disclosing Party’s Confidential Information.
+
+12.8.Ti=Post-termination
+
+12.8.sec=Notwithstanding the expiry of the term of this Agreement or a termination for any reason, the secrecy and non-use obligations of the Receiving Party shall continue for five years after expiry of such term or such termination of this Agreement. 
+
+13.Ti=WARRANTIES
+
+13.1.Ti=Warranty
+
+13.1.0.sec=Each Party warrants that, on the date of each delivery of a Milestone and of the [Work] and for a period of at least 24 months after each such delivery, the Milestones or [Work] shall:
+
+13.1.1.sec=conform to the specifications and product requirements in the Project Description;
+
+13.1.2.sec=be free of defects in materials and workmanship;
+
+13.1.3.sec=not infringe any intellectual property right of any third party;
+
+13.1.4.sec=in all material respects comply with all applicable laws and regulations; and
+
+13.1.5.sec=be free from liens, encumbrances and other claims of third parties.
+
+13.2.Ti=Failing specifications
+
+13.2.sec=To the extent that no grade or quality was specified in respect of the Milestones or [Work], the Milestones or [Work] shall in any case be of good quality and at least satisfy the customary standards commonly adopted in the industry in respect of quality, safety, suitability and workmanship. The warranty period in this Article 13 shall be extended by the period during which the delivered ‘[Work]’ cannot be used as a result of a failure to comply with the warranties.
+
+14.Ti=INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS
+
+14.1.Ti=Indemnity
+
+14.1.0.sec=The Party that provides Background IPR or is solely responsible for delivering a Milestone or certain products, services or technology of the [Work] as clearly identified to be delivered by that Party in the Project Description (the Indemnifying Party), at its sole expense, shall:
+
+14.1.1.sec=defend any legal proceeding initiated by a third party against the other Party, any of its Affiliates, their directors or employees (the Indemnified Parties) to the extent that the proceeding includes a claim that such Background IPR, Milestone, product, service or technology (the Infringing Goods) directly infringe such third party’s Intellectual Property Rights (a Claim); and
+
+14.1.2.sec=hold the Indemnified Parties harmless against damages awarded by judgment in and all reasonable costs related to such proceeding to the extent directly attributable to such Claim.
+
+
+14.2.2.Ti=Indemnity requirements
+
+14.2.0.sec=The Indemnifying Party has no obligation or liability to the Indemnified Parties in connection with any Claim referred to in Section 14.1:
+
+14.2.1.0.sec=if the Indemnifying Party is not:
+
+14.2.1.1.sec=promptly notified in writing of any such Claim;
+
+14.2.1.2.sec=granted the sole right to control and direct any discovery, the preparation, defence and settlement of such Claim, including the selection of counsel; and
+
+14.2.1.3.sec=provided full reasonable assistance and cooperation by the Indemnified Parties in such discovery, preparation, settlement or defence of the Claim;
+
+14.2.2.sec=to the extent that such Claim is attributable to specifications, designs or instructions provided by the Indemnified Parties; or
+
+14.2.3.sec=to the extent the Claim is based on any prototypes, risk production units, or access-protected parts of the Infringing Goods the use of which has not been expressly permitted; or
+
+14.2.4.sec=for any unauthorised use or distribution of the Infringing Goods or use beyond the Specifications or the Project Description; or
+
+14.2.5.0.sec=to the extent that the Claim arises from:
+
+14.2.5.1.sec=a modification of the Infringing Goods and the infringement would have been avoided without such modification; or
+
+14.2.5.2.sec=the combination of the Infringing Goods with any other product, service or technology (other than provided for as part of the Specifications or the Project Description);
+
+14.2.6.sec=to the extent a Claim arises from the Indemnified Parties’ continued manufacture, use, sale, offer for sale, importation or other disposition or promotion after the Indemnifying Party’s notice to the Indemnified Parties that the Indemnified Parties shall cease such activity, provided such notice shall only be given if the Infringing Goods are, or are likely to become, the subject of such a claim of infringement; or
+
+14.2.7.sec=for any costs or expenses incurred by the Indemnified Parties without the Indemnifying Party’s prior written consent; or
+
+14.2.8.sec=to the extent the Claim is based directly or indirectly upon the quantity or value of products manufactured by means of the Infringing Goods or upon the frequency of use or the amount of use of the Infringing Goods irrespective of whether such claim alleges that the Infringing Goods as such, or their use, infringe or contribute to the infringement of any Intellectual Property Rights of the party asserting the Claim; or
+
+14.2.9.sec=for infringement of any third party’s Intellectual Property Rights covering the manufacture, testing or application of any assembly, circuit, combination, method or process in which the Infringing Goods may have been used.
+
+14.2.00.sec=The Indemnified Parties shall indemnify the Indemnifying Party against any damages or costs arising from or connected with Claims to the extent based on the exceptions referred to in paragraph (b) through (f) (inclusive), (h) or (i), and shall reimburse all costs incurred by the Indemnifying Party in defending the Claim, provided the Indemnifying Party gives the Indemnified Parties prompt notice in writing of any such Claim.
+
+
+
+14.3.Ti=Remedies
+
+14.3.sec=If any Infringing Goods are, or are likely to become, the subject of a Claim, the Indemnifying Party shall have the right, but no obligation, to:
+
+14.3.1.sec=procure for the Indemnified Parties the right to continue to use or sell the Infringing Goods;
+
+14.3.2.sec=replace or modify the Infringing Goods in such a way as to make the modified Infringing Goods non-infringing.
+
+14.4.Ti=General limitation
+
+14.4.sec=Subject to the provisions of this Agreement, this Article 14 states Indemnifying Party’s entire liability and obligation to the Indemnified Parties and the Indemnified Parties’ sole remedy in respect of any actual or alleged infringement of any Intellectual Property Rights.
+
+CHAPTER IV.	GENERAL MATTERS
+
+15.Ti=REGULATORY MATTERS
+
+15.sec=The Parties shall co-operate in each of them being fully compliant with all regulatory requirements related to developing, having developed, manufacturing, having manufactured, using, having used, selling, distributing and otherwise (lawfully) disposing of any of the Milestones or any part resulting from the Project. Except as otherwise agreed, the costs of any required regulatory support shall be borne by the Party benefitting from it.
+
+16.Ti=FORCE MAJEURE
+
+16.1.Ti=Definition
+
+16.1.sec=In this Article 16, Force Majeure means all circumstances beyond the reasonable control of the Party concerned, including without limitation, acts of God, earthquake, flood, storm, lightning, war, riot, civil disturbance, fire, explosion, terrorism, sabotage, strike, lockout, slowdown, labour disturbances, accident, epidemic, difficulties to obtain required raw materials or labour, lack of or failing transportation, breakdown of plant or essential machinery, emergency repair or maintenance, breakdown of public utilities, changes of law, statutes, regulations or any other legislative measures, acts of governments, supranational organizations or other public or administrative agencies, orders or decrees of any court, acts of third parties, delay in delivery or defects in goods or materials supplied by suppliers or subcontractors or an inability to obtain or retain necessary authorizations, permits, easements or rights of ways. 
+
+16.2.Ti=Duties to inform and cooperate
+
+16.2.sec=A Party prevented to fulfil its obligations duly and timely because of an event of Force Majeure shall inform the other Party promptly, both orally and in writing, specifying the cause of Force Majeure and how it may affect its performance, including a good faith best estimate of the likely scope and duration of interference with its obligations, and shall make best efforts to terminate or remove as soon as practicable the Force Majeure circumstances. Both Parties shall consult each other in order to minimize all damages, costs and possible other negative effects.
+
+16.3.Ti=Effects
+
+16.3.sec=The Party prevented to fulfil its obligations shall not be required to remove any cause of Force Majeure or to replace or provide any alternative to the affected source of supply or the affected facility if that would require additional expenses or a departure from its normal practices, or to make up for any quantities not supplied. If an event of Force Majeure has occurred, the Party prevented to fulfil its obligations is entitled to allocate, in a manner it considers reasonable, the available quantities of Products amongst its customers and its own requirement. 
+
+17.Ti=TERM AND TERMINATION
+
+17.1.Ti=Term
+
+17.1.sec=This Agreement shall be effective as of 1 January 2014 [until terminated by either Party].  [Optional: A Party may terminate this Agreement with effect from the end of the then current term by giving the other Party a written notice of no less than [three months] before its expiry.]
+
+17.2.Ti=Material breach
+
+17.2.sec=A Party may terminate this Agreement at any time for a material or persistent breach by the other Party. Where such breach is capable of being remedied, a Party may only terminate if the breaching Party has not remedied such breach within [90 days] after giving a written notice of such breach. 
+
+17.3.Ti=Immediate termination
+
+17.3.0.sec=A Party may terminate this Agreement with immediate effect by written notice, if the other Party: 
+
+17.3.1.sec=shall be dissolved or liquidated, is declared bankrupt or otherwise the subject of suspension of payment or other insolvency proceedings, or if it must reasonably be expected to be unable to meet its obligations under this Agreement;
+
+17.3.2.sec=fails to comply with the laws and regulations to which it is subject; or
+
+17.3.3.sec=is subject to a change of control or if the management of the other Party is changed and such change is in the reasonable opinion of the terminating Party (potentially) detrimental to its business interests.
+
+17.4.Ti=Existing obligations
+
+17.4.sec=Notwithstanding the expiry or termination of this Agreement, each Party shall procure the due and timely performance of all obligations assumed by it prior to such expiry or termination. Except in the event that this Agreement is terminated for breach of contract, no Party shall be required to make any payment for termination or expiration of this Agreement. Provisions which, by their very nature, are intended to continue notwithstanding an expiry or termination of this Agreement, shall continue in full force and effect.
+
+17.5.Ti=Termination settlement
+
+17.5.sec=In case of a termination notice as provided in this Article 17, the Parties shall consult with each other to find an amicable agreement concerning the close-out phase of a Project or of any Milestone.
+
+18.Ti=MISCELLANEOUS
+
+18.1.Ti=Further assurances
+
+18.1.sec=The Parties shall cooperate with each other and execute to the other Party such forms and documents and take such other actions as may reasonably be requested from time to time in order to carry out, evidence or confirm the other Party’s rights or obligations or as may be reasonably necessary or helpful to give effect to the provisions of this Agreement.
+
+18.2.Ti=Amendments
+
+18.2.sec=No amendment of this Agreement shall be binding upon either Party, unless it is in writing and duly signed by both Parties.
+
+18.3.Ti=Assignment
+
+18.3.sec=Neither Party shall assign or transfer its rights or obligations under this Agreement in whole or in part without the prior written consent of the other Party (which shall not be unreasonably withheld or delayed). 
+
+18.4.Ti=Independent contractors
+
+18.4.sec=The Parties are independent contractors. No Party shall have any power or authority to assume on behalf of or in the name of the other Party any obligations or duties or to bind the other Party to any agreement, obligation or other commitment vis-à-vis any third party. 
+
+18.5.Ti=Waivers
+
+18.5.sec=A failure of a Party to enforce any of the provisions of this Agreement shall in no event be considered a waiver of such provision and a waiver of a provision by a Party shall not preclude that Party from later enforcing any other provision of this Agreement. No waiver by a Party of any breach or default by the other Party shall operate as a waiver of any succeeding breach or other default of the same or any other provision of this Agreement. No waiver shall have any effect unless it is specific and in writing. 
+
+18.6.Ti=Severability
+
+18.6.0.sec=If any provision in this Agreement is found to be invalid or unenforceable in any respect in any jurisdiction: 
+
+18.6.1.sec=the validity or enforceability of such provision shall not in any way be affected in respect of any other jurisdiction and the validity and enforceability of the remaining provisions shall not be affected, unless this Agreement reasonably fails in its essential purpose; and
+
+18.6.2.sec=the Parties shall substitute such provision by a valid and enforceable provision approximating to the greatest extent possible the essential purpose of the invalid or unenforceable provision.
+
+18.7.Ti=Export or import control obligations
+
+18.7.sec=The Parties undertake with each other to comply strictly with all applicable laws and regulations pertaining to EU export controls and the U.S. Export Administration or export or import restrictions of other applicable jurisdictions. If the performance or a delivery by one Party is subject to an export or import license being granted by a governmental authority under any applicable law or regulation, or otherwise restricted or prohibited due to export or import control laws or regulations, such Party shall notify the other Party of such fact as soon as they become aware of such requirement.
+
+19.Ti=APPLICABLE LAW AND DISPUTE RESOLUTION
+
+19.1.Ti=Applicable law
+
+19.1.sec=This Agreement shall be governed by the laws of [the Netherlands]. 
+
+19.2.Ti=Jurisdiction
+
+19.2.sec=Any disputes arising out of or in connection with this Agreement shall exclusively be referred to the competent courts of [Amsterdam, the Netherlands].
+
+
+20.Ti=INTERPRETATION
+
+20.1.Ti=Definitions. In this Agreement:
+
+20.1.sec=Acceptance Tests means the tests established in the Project Description and such acceptance tests as each Party deems appropriate to verify whether the Milestones or [Work], is capable of meeting the Specifications.
+
+20.2.sec=Accepting Party has the meaning ascribed to it in Section 4.1.
+
+20.3.sec=Adopting Party has the meaning ascribed to it in Section 2.2.
+
+20.4.sec=Affiliate means, in relation to a person, any company or other entity, whether or not a legal person, which directly or indirectly controls, is controlled by or is under joint control with that person. For this purpose, a person is deemed to control a company or entity if it (a) owns, directly or indirectly, more than 50 percent of the capital of the other company, or (b) in the absence of such ownership interest, substantially has the power to direct or cause the direction of the management and set the policies of such company or entity.
+
+20.5.sec=Background IPR means, by reference to a Party, all Intellectual Property Rights, excluding Foreground IPR, (a) owned by such Party or any of its Affiliates, or (b) licensed or made available by a third party to such Party and under which such Party is authorized to grant licenses.
+
+20.6.sec=Change Impact Notice has the meaning ascribed to it in Section 2.2.
+
+20.7.sec=Change Request has the meaning ascribed to it in Section 2.2.
+
+20.8.sec=Claim has the meaning ascribed to it in Section 14.1.
+
+20.9.sec=Confidential Information has the meaning ascribed to it in Section 12.1.
+
+20.10.sec=Delivering Party has the meaning ascribed to it in Section 4.1.
+
+20.11.sec=Disclosing Party has the meaning ascribed to it in Section 12.1.
+
+20.12.sec=Foreground IPR means all Intellectual Property Rights that arise as a result of or in the context of any activity pursuant to this Agreement.
+
+20.13.sec=Indemnified Party has the meaning ascribed to it in Section 14.1.
+
+20.14.sec=Indemnifying Party has the meaning ascribed to it in Section 14.1.
+
+20.15.sec=Infringing Goods has the meaning ascribed to it in Section 14.1.
+
+20.16.sec=Intellectual Property Rights means unpatented inventions, Patents, trademarks, service marks, trade names, domain names, copyrights (including rights in software), moral rights, rights in designs, Know How, database rights, topography rights, mask work rights, utility models and all other intellectual property rights and forms of protection of a similar nature, licences to such rights, in each case whether registered or pending registration, and rights to apply for any such rights.
+
+20.17.sec=Key People has the meaning ascribed to it in Section 6.1.
+
+20.18.sec=Know How means all knowledge, drawings, specifications, samples, models, instructions, algorithms, working methods, ideas, concepts, technology, applied development engineering data, reports, notes and all other technical or commercial information, data and documents of any kind.
+
+20.19.sec=Milestone means a deliverable or milestone as defined in connection with a Project, and failing such definition the agreed result of such a Project.
+
+20.20.sec=Patents means all patents and patent applications in any jurisdiction in the world, including any divisional, continuation, continuation-in-part, reissue, renewal, re-examination or extension thereof.
+
+20.21.sec=Project Committee has the meaning ascribed to it in Section 8.1.
+
+20.22.sec=Project Coordinator has the meaning ascribed to it in Article 7.
+
+20.23.sec=Project Description has the meaning ascribed to it in Annex 1.
+
+20.24.sec=Project means the development work and required results as specified in the Project Description.
+
+20.25.sec=Proposing Party has the meaning ascribed to it in Section 2.2.
+
+20.26.sec=Receiving Party has the meaning ascribed to it in Section 12.1.
+
+20.27.sec=Specifications means the product specifications, quality requirements, properties, features, functionalities, attributes of any part of the [Work] as established in the Project Description, and failing such specifications the [Work] shall in any event satisfy the customary standards commonly adopted in the industry in respect of quality, safety, suitability and workmanship.
+
+20.28.sec=Time Schedule means the time schedule in the Project Description, or as agreed between the Parties from time to time.
+
+20.29.sec=Working Group has the meaning ascribed to it in Section 8.4.
+
+
+20.2.Ti=Interpretation
+
+20.0.sec=Except as otherwise defined, in this Agreement:
+
+20.1.sec=references to a communication in writing shall include e-mail and electronic messages accessible and printable by commonly used software applications;
+
+20.2.sec=references to Articles, Sections, Schedules and Annexes are references to articles and sections of and schedules and annexes to this Agreement.
+
+20.3.Ti=Schedules and priority. The Schedules and Annexes are an integral part of this Agreement and references to this Agreement shall include its Schedules and Annexes. In the event of any ambiguity or inconsistency between the provisions of a Schedule or an Annex and in the body of this Agreement, the latter shall prevail.
+
+
+
+Annex.1.Ti=Annex 1. Statement of Work
+
+Below is a check list of matters that could be included in a Statement of Work, the further contents of which are determined by the Agreement:
+
+Annex.1.0.sec=DRAFTING MODEL CONTRACTS
+
+Annex.1.1.Ti=Scope and background
+
+Annex.1.1.1.sec=Explain level of innovation or discipline
+
+Annex.1.1.2.sec=Identify know how and expertise expected to be already available at each of the parties (or each Party's appropriateness to provide certain know how or expertise)
+
+Annex.1.2.Ti=Objectives and deliverables
+
+Annex.1.2.1.sec=[Commercial (applications …)]
+
+Annex.1.2.2.0.sec=Technical specifications or requirements to be met:
+
+Annex.1.2.2.1.sec=…
+
+Annex.1.2.2.2.sec=…
+
+Annex.1.2.3.sec=[Deliverables by individual parties (separate from joint deliverables)]
+
+Annex.1.3.Ti=Organisation
+
+Annex.1.3.1.sec=People + roles
+
+Annex.1.3.2.sec=Resources (i.e., number of FTE and available budgets) 
+
+Annex.1.3.3.sec=Reporting structure
+
+Annex.1.4.Ti=Project timing (including criteria for each phase)
+
+Annex.1.4.1.sec=Starting date
+
+Annex.1.4.2.0.sec=Define phases (incl. specific time schedule), if applicable, like:
+
+Annex.1.4.2.1.sec=Further definition of the project scope
+
+Annex.1.4.2.2.sec=Concept development
+
+Annex.1.4.2.3.sec=Prototype development
+
+Annex.1.4.2.4.sec=Validation of the Work
+
+Annex.1.4.2.5.sec=Upscaling
+
+Annex.1.4.2.6.sec=…
+
+Annex.1.4.3.sec=Dates of work consultations and interim reporting
+
+Annex.1.5.Ti=Evaluation and results reporting
+
+

--- a/Doc/GH/Paris2/WeAgree/04_Trademark-License/Form/0.md
+++ b/Doc/GH/Paris2/WeAgree/04_Trademark-License/Form/0.md
@@ -1,0 +1,542 @@
+
+Why.1.sec=(A)	Licensor is the owner of the Trademark (capitalised terms are defined in Article 1).
+
+Why.2.sec=(B)	Licensee wishes to [Either: use [OR: [OPTIONAL: (according to the scope of licensed use): to manufacture, promote, distribute and sell] the Products [to the Market in the Territory]. Licensor is willing to grant Licensee a licence under the Trademark.
+
+1.Ti=INTERPRETATION
+
+1.1.Ti=Definitions. 
+
+1.1.0.sec=In this Agreement:
+
+1.1.sec=Affiliate means, in relation to a person, any company or other entity, whether or not a legal person, which directly or indirectly controls, is controlled by or is under joint control with that person. For this purpose, a person is deemed to control a company or entity if it (a) owns, directly or indirectly, more than 50 percent of the capital of the other company, or (b) in the absence of such ownership interest, substantially has the power to direct or cause the direction of the management and set the policies of such company or entity.
+
+1.1.sec=Confidential Information means any information of a non-public, confidential or proprietary nature, whether of commercial, financial or technical nature, customer, supplier, product or production-related or otherwise, including samples, information relating to raw materials, specifications, software, patent applications, process designs, process models, materials and ideas, disclosed by a Party (the Disclosing Party) to the other Party (the Receiving Party). Such information may be disclosed in any form, provided that it is disclosed reasonably in connection with this Agreement.
+
+1.2.sec=Market means the market segment of [edit.Market segment].
+
+1.3.sec=Products means [Option 1: the products listed in Annex 2, as amended by Licensor from time to time ] [Option 2: specify or describe the products] .]
+
+1.4.sec=Territory means [specify countries or geographical scope].
+
+1.5.sec=Trademark means the trademark identified on Annex 1.
+
+
+1.2.Ti=Interpretation
+
+1.2.0.sec=Except as otherwise defined, in this Agreement:
+
+1.2.1.sec=references to a communication in writing shall include e-mail and electronic messages accessible and printable by commonly used software applications;
+
+1.2.2.sec=references to Articles, Sections and Annexes are references to articles and sections of and annexes to this Agreement.
+
+1.3.Ti=Annexes and priority
+
+1.3.sec=The Annexes are an integral part of this Agreement and references to this Agreement include its Annexes. In the event of any ambiguity or inconsistency between the provisions of an Annex and in the body of this Agreement, the latter prevails.
+
+1.4.Ti=Best efforts
+
+1.4.sec=Where any obligation is qualified or phrased by reference to use reasonable endeavors, best efforts or wording of a similar nature, it means the efforts that a determined and reasonable person desirous of achieving a result would use in similar circumstances to ensure that such result is achieved as expeditious as possible. The person under such an obligation shall, if a result aimed at is not achieved or achieved after delay, upon the request by a Party provide evidence of (a) all actions taken in order to fulfil this obligation, (b) any choices made where two or more alternative courses of action would have been reasonably appropriate, and (c) plausibly how any external factors (adversely) influenced its performance and the achieved result.
+
+2.Ti=LICENCE SCOPE
+
+2.1.Ti=Licence
+
+2.1.sec=Subject to the terms of this Agreement, Licensor hereby grants to Licensee, and Licensee hereby accepts from Licensor, a [Options: royalty-bearing, fully paid-up, royalty-free], [Options: exclusive, non-exclusive, sole] licence, [Options: with, without] the right to sub-license, [Option 1: to use [Option 2: to manufacture, promote, distribute and sell] the Products [Optional: to the Market in the Territory] under the Trademark (the Licence).
+
+Note=Optional.
+
+2.2.Ti=Limited right to sub-license
+
+2.2.0.sec=Subject to the limitations applicable to Licensee, Licensee is entitled to grant sub-licences to:
+
+2.2.1.0.sec=[Optional: (sub-licensing to Affiliates): its Affiliates, which are not also an Affiliate of a third party, with a (limited) right to use the Trademark, provided that such sub-license terminates:
+
+2.2.1.1.sec=upon termination of this Agreement; or
+
+2.2.1.2.sec=upon such sub-licensed Affiliate ceasing to be an “Affiliate” of Licensee;
+
+2.2.2.0.sec=[Optional: (sub-licensing to suppliers and subcontractors): its suppliers and subcontractors, with a (limited) right to use the Trademark for Licensee’s exclusive benefit, provided that the sub-license shall be no more extensive than is strictly required for providing such subcontractor's services to Licensee, and provided furthermore that such sub-license terminates:
+
+2.2.2.1.sec=upon termination of this Agreement; or
+
+2.2.2.2.sec=upon such subcontractor ceasing to be a subcontractor of Licensee for the sub-licensed type of services or supplies.
+
+2.2.2.00.sec=Each sub-licence as referred to in this paragraph (b) shall be subject to the prior approval of Licensor, which approval shall not unreasonably be withheld or delayed.
+
+Note=Optional:
+
+2.2.3.sec=If Licensee wishes to grant any sub-licence other than expressly permitted in this Section 2.2, the Parties shall negotiate in good faith the terms of such sub-licence.
+
+Note=Optional:
+2.3.Ti=Exclusivity
+
+2.3.sec=The exclusivity of the Licence only applies to {2.3.2.sec}.
+
+2.3.2.=[Z/Alt.3]
+
+2.3.2.Alt1.sec=the Territory
+
+2.3.2.Alt2.sec=the territory of [specify country or geographical area within the Territory as defined above
+
+2.3.2.Alt3.sec=The exclusivity of the Licence shall terminate [upon expiry of an initial term of [specify] months after the date of this Agreement
+
+2.4.Ti=Changes to Annex 1
+
+2.4.sec=Licensor may, at its discretion, add or remove trademark symbols, logos, word marks or other indicators in Annex 1, subject to prior notice to Licensee.
+
+3.Ti=LICENCE RESTRICTIONS
+
+3.1.Ti=General limitation
+
+3.1.sec=Licensee's rights under this Agreement shall be no more extensive in scope and duration than Licensor's rights and limited to the Trademark in Annex 1.
+
+3.2.Ti=Limitations of use
+
+3.2.sec=Licensee shall not do, or omit to do, anything to prejudice the distinctiveness, validity or goodwill of the Trademark, to diminish the rights of Licensor in the Trademark or to impair any registration of the (license of the) Trademark. Licensee shall not use the Trademark in its company, business, trade or domain names or trademarks.
+
+3.3.Ti=Similar marks
+
+3.3.sec=Licensee shall not use any trademark, trade name or domain name [in the Market in the Territory] which so resemble the Trademark that it is likely to cause confusion or deception.
+
+3.4.Ti=Use only in relation to business
+
+3.4.sec=Licensee shall use the Trademark only in relation to its business in connection with the Products. Other use of the Trademark is subject to the prior approval of Licensor.
+
+Note=Optional (important note): many competition laws prohibit including a termination ground, which attempts to prevent that a licensee challenges the validity of the trademark: 
+
+3.5.Ti=No challenge of validity
+
+3.5.sec=Licensee shall not dispute the validity of the Trademark or the rights of Licensor to the Trademark.
+
+3.6.Ti=Sales outside Territory
+
+3.6.sec=Licensee shall not actively solicit orders for Products from persons outside the Territory. [Optional (important: in case the Territory is an EU member state): Nothing in this Agreement shall prevent Licensee to sell its Products outside the Territory into an EU member state if it did not actively solicit such orders.
+
+4.Ti=TRADEMARK USAGE AND MARKETING
+
+4.1.Ti=Branding guidelines
+
+4.1.sec=Licensee shall strictly comply with Licensor’s Trademark branding guidelines, [Option 1: attached as Annex 4][Option 2:  available at [insert reference to Licensor’s website]] as amended from time to time.
+
+4.2.Ti=Marketing and sales efforts
+
+4.2.sec=Licensee shall use its best efforts to achieve maximum sales of the Products and generally to expand the distribution of the Products [to the Market in the Territory].
+
+4.3.Ti=Adequate sales support
+
+4.3.sec=Licensee shall maintain for its own risk and account a sales organisation adequate and competent to promote and sell the Products effectively and to reputable and financially viable parties and shall provide consumer services in relation to the Products, including in respect of repair and maintenance services.
+
+4.4.Ti=Marketing materials
+
+4.4.sec=Licensee shall not use any advertising, marketing or other materials, including on internet, in relation to the Trademark or the Products without the prior written approval of Licensor.
+
+Note=[Optional: 
+
+4.5.Ti=Indication of origin
+
+4.5.1.0.sec=On each Product and each package containing the Product, Licensee shall indicate that the Trademark is owned by Licensor, by printing the following notice:
+
+4.5.1.1.sec=“Made by [insert name Licensee] in [specify place] under licence from [insert name Licensor]. [Identify wordmark] is the [registered] trademark of [insert name Licensor].”
+
+Note=[Optional: 
+4.5.2.sec=In all marketing or other materials, the Trademark shall be identified as a registered trademark with the symbol ® or as a trademark with the symbol TM.
+
+
+5.Ti=PRODUCTS, PACKAGING AND QUALITY ASSURANCE
+
+5.1.Ti=Product specifications
+
+5.1.1.sec=Licensee shall manufacture the Products in accordance with the specifications, standards and instructions provided by Licensor from time to time. [Optional: The initial specifications of the Products are attached as Annex 3.] The Products may not adversely affect reputation or goodwill of Licensor or the Trademark. Licensee shall comply with best industry practices and standards, among others on quality, health, environment and safety.
+
+5.1.2.sec=Licensor shall give Licensee written notice of any changes to the specifications and standards referred to in this Section 5.1 and Licensee shall implement such changes as soon as reasonably practicable.
+
+5.1.=[Z/paras/s2]
+
+5.2.Ti=Samples and packaging materials
+
+5.2.sec=Prior to market, sell, distribute or otherwise use a series of Products, Licensee shall submit to Licensor for approval a model or sample of the Products and of all related packaging and advertising materials. Licensor may determine in its sole discretion whether the model or sample qualifies as “Product” as identified or described in Annex 3.
+
+5.3.Ti=Inferior or rejected goods
+
+5.3.sec=Licensee shall not, and shall not permit any third party to, market, sell, distribute or otherwise use for any purpose, (a) any Products which are damaged or defective, or (b) any products which Licensor rejected by virtue of Section 5.2 and products which contain or use the Trademark.
+
+5.4.Ti=Quality audits
+
+5.4.sec=Subject to reasonable prior notice, Licensee shall permit Licensor to, at its own expense, access Licensee’s offices and other premises in order to verify Licensee’s compliance with Licensor’s standards of quality and other obligations under this Agreement.
+
+6.Ti=LICENCE FEES
+
+Note=[Optional: 
+
+6.1.Ti=Licence entrance fee
+
+6.1.sec=Licensee shall pay to Licensor an initial fee of [specify amount and currency] within [30] days after the execution of this Agreement.
+
+6.2.Ti=Net Sales royalty
+
+6.2.1.sec=Licensee shall pay to Licensor a recurring licence fee of [specify] percent, based on the total amount invoiced by Licensee and its Affiliates for the Products, excluding:
+
+6.2.1.sec=rebates, returns and sale discounts to Licensee’s customers;
+
+6.2.2.sec=transportation, packaging and insurance costs;
+
+6.2.3.sec=taxes and duties paid on the sale of the Products; and
+
+6.2.4.sec=sales to Licensee’s Affiliates (for the avoidance of doubt, notwithstanding the amounts invoiced by such Affiliates to any third-party customers).
+
+Note=[Alternative royalty structures might be: a per-unit royalty and percentage rate variable over the term, e.g. increasing over the term based on the assumption that sales increase over time; or partly a fixed amount per royalty period (being an incentive to exceed certain sales levels, or avoiding price dumping behaviour) and partly a percentage of net sales.]
+
+Note=[Optional: 
+
+6.3.Ti=Minimum licence fee
+
+6.3.sec=Annually within one month after the end of a 12-months term of this Agreement, Licensee shall pay to Licensor a minimum royalty amount of [specify amount] [Optional: less any licence fees accrued and paid to Licensor during such preceding 12-months term].
+
+6.4.Ti=Royalty reporting
+
+6.4.sec=Within [ten] days after the end of each [Specify: one / three / six months] period, Licensee shall provide Licensor with a written statement of the licence fees accrued during such preceding period. The statement must specify the elements identified in Section 6.2 (including the amounts in paragraphs 6.2(a), 6.2(b), 6.2(c) and 6.2(d)).
+
+6.5.Ti=Books and records
+
+6.5.sec=Licensor shall adequately account for all sales of all Products under the Trademark in its books and records.
+
+6.6.Ti=Royalty audits
+
+6.6.1.sec=Subject to a [ten] days written notice, Licensee shall permit Licensor to have an auditor of a certified accounting firm selected by Licensor audit Licensee’s accounts and records, during business days and normal working hours, in order to verify the accuracy of the reported net sales amounts and the calculated licence fees.
+
+6.6.2.sec=Licensee shall provide the auditor with all assistance and cooperation as the auditor may reasonably need in order to perform its audit efficiently and effectively. Except in case of any structural or material irregularities, (a) an audit shall not be conducted more than once per year, and (b) the costs of the audit shall be borne by Licensor.
+
+Note=[Optional: 
+
+6.6.3.sec=If an audit reveals any underpayment of licence fees, Licensee shall promptly make up for the underpayment together with interest on such amount, calculated from the due date of such underpaid amount, at the rate specified in Section 7.3.
+
+Note=continuation of [Optional:
+
+6.6.4.sec=If an audit reveals any overpayment of licence fees, Licensor shall promptly make up for such overpayment. If such overpayment was caused by a mistake of Licensor, Licensor shall also pay interest on such amount, calculated from the date of receipt of such overpaid amount, at the rate specified in Section 7.3.
+
+Note= "6.7" in 6.6.5.sec should be "6.6" - right?  
+
+6.6.5.sec=This Section 6.7 shall remain in effect for a period of one year after a termination of this Agreement.
+
+
+7.Ti=PAYMENT
+
+7.1.Ti=Payment term
+
+7.1.sec=Licensee shall pay all amounts due pursuant to Article 6 to Licensor in [specify currency], within 30 days from the end of the royalty period referred to in Section 6.4.
+
+7.2.Ti=Late payments
+
+7.2.sec=If Licensee fails to pay the amounts at the agreed time, Licensor shall fix to Licensee an additional period of time of [specify the length] for performance of payment. If Licensee fails to pay the amounts at the expiration of the additional period, Licensor may declare this Agreement avoided in accordance with Article [14].
+
+Note=[Optional:
+
+7.3.Ti= Interest
+
+7.3.sec=If Licensee fails to pay the licence fees within the agreed time, Licensor shall in any event be entitled, without limiting any other rights it may have, to charge interest on the outstanding amount (both before and after any judgment) at a rate of [specify percent] per annum. [Alternatively: Specify other rate of interest agreed by the Parties.
+
+7.4.Ti=Taxes
+
+7.4.0.sec=The following applies in respect of any value added tax (VAT), sales tax, income tax, consumption tax or any other similar tax, duty, fee, levy or other governmental charge, customs duties and other levies (Taxes):
+
+7.4.1.sec=all amounts in this Agreement are gross amounts but exclusive of any Taxes, except as specified otherwise; and
+
+7.4.2.sec=if any payment under this Agreement is subject to any Taxes, Licensor shall be entitled to charge such Taxes to Licensee, which shall be paid by Licensee in addition to the payments pursuant to this Agreement.
+
+7.4.00.sec=To the extent that licence fee payments are subject to withholding Taxes, Licensee shall pay such additional amount to Licensor as shall, after deduction of such withholding Taxes, be equivalent to the licence fees otherwise payable under this Agreement. Licensee shall provide Licensor with true copies of the relevant tax deduction certificates.
+
+8.Ti=INTELLECTUAL PROPERTY RIGHTS
+
+8.1.Ti=Ownership
+
+8.1.sec=The Trademark is licensed, not sold or assigned. Licensor is the owner of the Trademark and the owner of all trademark and domain name applications and registrations, containing the Trademark. Except as expressly provided in this Agreement, no other rights or licences are granted or implied.
+
+8.2.Ti=Accrual of rights
+
+8.2.sec=All rights to and goodwill associated with the Trademark resulting from Licensee’s use of the Trademark shall accrue to Licensor. Licensee shall do all such things as may be necessary to vest all rights to and goodwill in the Trademark in the name of Licensor.
+
+8.3.Ti=Artwork
+
+8.3.sec=All copyrights and other intellectual property rights in any artwork used for the labelling or packaging of the Products shall be owned by Licensor.
+
+8.4.Ti=Reputation and goodwill
+
+8.4.sec=Licensee shall assist Licensor in protecting Licensor’s reputation and the goodwill associated with the Trademark.
+
+9.Ti=REGISTRATIONS
+
+9.1.Ti=Trademark registration
+
+9.1.sec=Licensor shall maintain the existing registrations of the Trademark [in the key jurisdictions of the Market][in the Territory]. Licensee shall provide, at the request and expense of Licensor, all necessary assistance in applying for and maintaining such registrations.
+
+9.2.Ti=Prohibited registrations
+
+9.2.sec=Licensee shall not apply for or register a trademark or a domain name which in the opinion of Licensor is similar to the Trademark for any products or services. Upon Licensor’s request, Licensee shall assign the ownership of such trademark or domain name to Licensor.
+
+Note=[Optional: 
+
+9.3.Ti=Licence registration
+
+9.3.sec=The Parties are entitled to register the Licence at the trademark register or other relevant register [in the key jurisdictions of the Market][in the Territory][Optional:, such that the registration shall contain only the terms identified in Annex 2]. Licensor shall assist Licensee in obtaining the registration.
+Note=[Optional: (Is a registration of the Product required?): 
+
+9.4.Ti=Product registration
+
+9.4.sec=Licensee shall register the Products with the competent authorities and take all other administrative actions in relation to the Products, to the extent required to introduce, promote, market and sell the Products [in the Territory][to the Market]. Licensor shall cooperate in connection with such registration and other administrative actions in respect of the Products.
+
+9.5.Ti=Compliance with laws
+
+9.5.sec=Licensee shall comply with all laws and regulations applicable to the Licence.
+
+10.Ti=TRADEMARK INFRINGEMENTS
+
+10.1.Ti=Infringement
+
+10.1.0.sec=Licensee shall promptly notify Licensor of: 
+
+10.1.1.sec=any third party or any of its employees infringing (whether actual, threatening or suspected), misappropriating or passing-off the Trademark, or competing unfairly with or using without authorisation the Trademark, in each case identifying (if known) the persons involved.
+
+10.1.2.sec=any third party claim of ownership, infringement, misappropriation or passing-off of the Trademark, or unfair competition relating to the Trademark. Licensee shall not respond to any such claim and shall make no statement as to validity of the Trademark registration or application without the written approval of Licensor. Licensee shall make no admissions as to liability.
+
+10.1.00.sec=Licensee shall (a) only take actions after written approval of Licensor, and (b) refrain from discussing or accepting any settlement or compromising on any action (or on omitting to act).
+
+10.2.Ti=Enforcement action
+
+10.2.sec=Licensor has the sole right to determine what action (if any) shall be taken and by which Party. Licensor shall have control over legal proceedings arising out of any such action. Licensee shall assist Licensor in taking actions in connection with an infringement, including starting legal proceedings.
+
+10.3.Ti=Licensor’s indemnity
+
+10.3.sec=Licensor shall defend and indemnify Licensee against all claims, losses and damages made or incurred by third parties arising out of or in connection with (a) Licensee’s use of the Trademark in accordance with this Agreement, and (b) Licensor’s failure to comply with applicable laws and regulations [outside the Territory].
+
+10.4.Ti=Licensee’s indemnity
+
+10.4.sec=Licensee shall defend and indemnify Licensor against all claims, losses and damages made or incurred by third parties arising out of or in connection with (a) Licensee’s use of the Trademark other than in accordance with this Agreement, and (b) Licensee’s failure to comply with applicable laws and regulations.
+
+11.Ti=WARRANTIES
+
+11.1.Ti=Licensor’s warranty
+
+11.1.0.secLicensor warrants to Licensee that on the date of this Agreement:
+
+11.1.1.sec=it is the sole owner of the Trademark;
+
+11.1.2.sec=it is unaware of any infringement of the Trademark by any third party trademark, logo, design or similar indicators; and
+
+11.1.3.sec=has not received a notice claiming or alleging that the Trademark infringes the rights of a third party.
+
+11.2.Ti=Warranties
+
+11.2.0.sec=Each Party warrants to the other that entering into and performance of this Agreement by it:
+
+11.2.1.sec=does not constitute a breach of any obligation or duty by it or any of its Affiliates to any other person, any rights of any other person or any other legal provision; and
+
+11.2.2.sec=does not require any governmental or other approvals or, if any such approval is required, it has been obtained.
+
+12.Ti=LIMITATION OF LIABILITY
+
+Note=[Optional:
+ 
+12.1.Ti=No indirect damages
+
+12.1.sec=No Party shall be liable to the other Party by reason of any representation (unless fraudulent) or any implied warranty, condition or other term, for any loss of profit or any indirect, special or consequential loss or damage (whether caused by the negligence of that Party, its employees or agents or otherwise) in relation to the Trademark or Products (or any failure to supply them) or their resale by Licensee, or otherwise arising out of or in connection with this Agreement.
+
+Note=[Optional: 
+
+12.2.Ti=Limitation of liability
+
+Note=hazardj - broke this up into an outline:
+
+12.2.sec=In all cases in which a Party is liable towards the other Party for any damages or losses, such Party’s aggregate, cumulative liability under this Agreement shall not exceed [Option 1 (a reasonable, turnover-related amount): {12.2.2.sec}.
+
+12.2.2.Alt1.sec=[100 percent of] the amounts paid pursuant to this Agreement during the [12 months] preceding the event that gave rise to the claim]
+
+Note=[Option 2 (merely a fixed amount): 
+
+12.2.2.Alt2.sec=[insert fixed amount and currency]
+
+Note=[Option 3 (a reasonable, turnover-related amount with safeguards for the initial, risky period):
+
+12.2.2.Alt3.sec=the higher of [[100 percent of] the amounts paid pursuant to this Agreement during the [12 months] preceding the event that gave rise to the claim] and [insert fixed amount and currency]]
+
+Note=[Option 4 (a turnover-related amount with safeguards if the liable party has a very high cost base): 
+
+12.2.2.Alt4.sec=the lower of the amounts paid pursuant to this Agreement during the [12 months] preceding the event that gave rise to the claim] and [insert fixed amount and currency]
+
+12.2.2.=[Z/Alt/4]
+
+13.Ti=[OPTIONAL: CONFIDENTIALITY
+
+13.1.Ti=General
+
+13.1.sec=A Receiving Party shall not use Confidential Information for purposes other than in direct relation with this Agreement. The Receiving Party shall treat the Disclosing Party's Confidential Information with at least the same degree of care as it would use in respect of its own confidential information of similar importance, but in any event a reasonable level of care. A Receiving Party shall handle, test, use and keep the Disclosing Party's Confidential Information in conformity with all applicable legal requirements (if applicable). Except as provided otherwise, the Receiving Party shall not disclose, publish, disseminate or make accessible any part of the Disclosing Party’s Confidential Information, in any way or form, to anyone.
+
+13.2.Ti=Exemptions
+
+13.2.0.sec=The restrictions and obligations in this Article 13 shall not apply to the Disclosing Party’s Confidential Information, which: 
+
+13.2.1.sec=is or becomes generally available to the public other than as a result of a disclosure by the Receiving Party (or its representatives);
+
+13.2.2.sec=was received by the Receiving Party from a third party and not indirectly from the Disclosing Party in violation of any obligation of secrecy or non-use; or
+
+13.2.3.sec=was in the possession of the Receiving Party prior to disclosure or is developed independent from such Confidential Information, as is shown by competent evidence.
+
+13.3.Ti=Court orders
+
+13.3.sec=In case Confidential Information is required to be disclosed by the Receiving Party by virtue of a court order or statutory duty, the Receiving Party shall be allowed to do so, provided that it shall without delay inform the Disclosing Party in writing of receipt of such order or duty and enable the Disclosing Party reasonably to seek protection against such order or duty. 
+
+13.4.Ti=Delete or destroy
+
+13.4.sec=Upon the first request of a Disclosing Party, the Receiving Party shall without delay (a) return all their copies, samples and extracts of, and all other physical media containing, the Disclosing Party’s Confidential Information, and (b) delete or destroy (and have deleted or destroyed) all automated data containing the Disclosing Party’s Confidential Information.
+
+13.5.Ti=Post-termination
+
+13.5.sec=Notwithstanding the expiry or termination of this Agreement, the secrecy and non-use obligations of the Receiving Party shall continue for five years after expiry or termination of this Agreement. 
+
+14.Ti=TERM AND TERMINATION
+
+14.1.Ti=Term
+
+14.1.sec=This Agreement will take effect on the date of its signature by both Parties or, if signatures do not occur simultaneously, when the latest signature is given. Unless sooner terminated pursuant to Article 14.2, 14.3 or 14.4, this Agreement shall continue for a period of [specify period].
+
+14.2.Ti=Termination grounds
+
+14.2.0.secA Party shall be entitled to terminate this Agreement by giving written notice to the other if:
+
+14.2.1.sec=the other Party breaches any material obligation and such breach has not been remedied within [specify: 30 days] after receipt of a written notice indicating the breach and the possibility of termination;
+
+14.2.2.sec=the other Party shall be dissolved or liquidated, is declared bankrupt or otherwise insolvent, enters into suspension of payment proceedings, or if it must reasonably be expected to be unable to meet its obligations under this Agreement;
+
+14.2.3.sec=the financial condition of the other Party changes in such a way to render it reasonably unacceptable for the former Party to continue this Agreement; or
+
+14.2.4.sec=the other Party fails to comply with the laws and regulations to which it is subject.
+
+14.3.Ti=Material breach
+
+14.3.sec=Licensor may at its option terminate this Agreement forthwith by giving written notice to Licensee, if:
+
+14.3.1.sec=Licensee fails to produce samples of the Products under Article 5 in accordance with the specifications and to the reasonable satisfaction of Licensor on or before [specify date];
+
+14.3.2.sec=[Important note: many competition laws prohibit including a termination ground, which attempts to prevent that a licensee challenges the validity of the trademark: disputes the validity of the Trademark or the rights of Licensor to the Trademark;]
+
+14.3.3.sec=acts (or omits to act) such that, at the discretion of Licensor, it persistently dilutes, genericises or damages the reputation or goodwill of the Trademark; or
+
+14.3.4.sec=is the subject of a change of control or if the management is changed or if there is change in its sphere of activities and such change is reasonably (potentially) detrimental to Licensor’s business interests.
+
+
+14.4.Ti=Termination for convenience
+
+14.4.sec=Each Party may terminate this Agreement for convenience, by giving a six months written notice to the other Party.
+
+14.5.Ti=Other remedies
+
+14.5.sec=The rights to terminate this Agreement shall not prejudice any other right or remedy of either Party in respect of the breach concerned (if any) or any other breach.
+
+15.Ti=CONSEQUENCES OF TERMINATION
+
+15.1.Ti=Effects
+
+15.1.0.sec=Upon termination of this Agreement:
+
+15.1.1.0.sec=Repurchase right. Licensor shall be entitled to repurchase from Licensee all or part of any stocks of the Products then held by Licensee at their invoice value or the value at which they stand in the books of Licensee, whichever is lower, subject to the following provisions:
+
+15.1.1.1.sec=Licensor shall arrange and bear the cost of transport and insurance;
+
+15.1.1.2.sec=Licensee may sell stocks for which it has accepted orders from customers prior to the date of the termination notice, or in respect of which Licensor does not, by giving written notice to Licensee within [specify period] after the date of termination, exercise its right to repurchase; and
+
+15.1.1.3.sec=for those purposes and to the necessary extent, the provisions of this Agreement shall continue in full force and effect.
+
+15.1.2.Ti=Return of samples
+
+15.1.2.sec=Licensee shall at its own expense send to Licensor or otherwise dispose of in accordance with the directions of Licensor all samples of the Products and any advertising, promotional or sales material relating to the Products then in the possession of Licensee.
+
+15.1.3.Ti=Outstanding invoices
+
+15.1.3.sec=Any outstanding unpaid amounts or invoices becomes immediately payable by Licensee and invoices in respect of Products ordered prior to termination but for which no fee has been reported yet shall be payable immediately.
+
+15.1.4.Ti=Cease promotion
+
+15.1.4.sec=Licensee shall cease to promote, market or advertise the Products or to make any use of the Trademarks or any other intellectual property of Licensor except for the purpose of selling any Products in respect of which Licensor does not exercise its right or repurchase.
+
+15.1.5.Ti=Existing registrations
+
+15.1.5.sec=Licensee shall at its own expense join with Licensor in procuring the cancellation or transfer of any registration in its name effected pursuant to Article 9.
+
+15.2.Ti=Continuing obligations
+
+15.2.sec=Provisions which, by their very nature, are intended to continue notwithstanding an expiry or termination of this Agreement, shall continue in full force and effect.
+
+16.Ti=MISCELLANEOUS
+
+16.1.Ti=Further assurances
+
+16.1.sec=The Parties shall cooperate with each other and execute to the other Party such forms and documents and take such other actions as may reasonably be requested from time to time in order to carry out, evidence or confirm the other Party’s rights or obligations or as may be reasonably necessary or helpful to give effect to the provisions of this Agreement.
+
+16.2.Ti=Amendments
+
+16.2.sec=No amendment of this Agreement shall be binding upon either Party, unless it is in writing and duly signed by both Parties.
+
+16.3.Ti=Assignment
+
+16.3.sec=No Party may assign rights or obligations of this Agreement without the consent of the other Party, which consent shall not unreasonably be withheld or delayed; except that Service Provider may, without such consent, on written notice to the other Party, assign any of its rights or obligations under this Agreement to its Affiliates. Notwithstanding the previous sentence, each Party may assign this Agreement without the prior consent of the other Party, to a purchaser of all or substantially all of the assets or a business of such Party, provided that such assignment shall not be to a competitor of the other Party in the subject field of this Agreement.
+
+16.4.Ti=Independent contractors
+
+16.4.sec=The Parties are independent contractors. No Party shall have any power or authority to assume on behalf of or in the name of the other Party any obligations or duties or to bind the other Party to any agreement, obligation or other commitment vis-à-vis any third party.
+
+16.5.Ti=Severability
+
+16.5.0.sec=If any provision in this Agreement is found to be invalid or unenforceable in any respect in any jurisdiction: 
+
+16.5.1.sec=the validity or enforceability of such provision shall not in any way be affected in respect of any other jurisdiction and the validity and enforceability of the remaining provisions shall not be affected, unless this Agreement reasonably fails in its essential purpose; and
+
+16.5.2.sec=the Parties shall substitute such provision by a valid and enforceable provision approximating to the greatest extent possible the essential purpose of the invalid or unenforceable provision.
+
+17.Ti=APPLICABLE LAW AND DISPUTE RESOLUTION
+
+17.1.Ti=Applicable law
+
+17.1.sec=This Agreement is governed by the laws of [the Netherlands]. 
+
+17.2.Ti=Jurisdiction
+
+17.2.sec=Any disputes arising out of or in connection with this Agreement shall exclusively be referred to the competent courts of [Amsterdam, the Netherlands].
+
+
+ 
+
+Annex.1.Ti=Annex 1. Trademarks
+
+[Insert the [TRADEMARK], including the registrations [and the applications for registration] in the Territory]
+
+[Insert trademark logos and trademark-related designs or indicators here]
+
+Annex.2.Ti=Annex 2. Pro forma Trademark licence
+
+Annex.2.1.Ti=Licence scope
+
+Clauses to be copy-pasted here include: the licence grant (Section 2.1) and (in case of permitted sublicensing) the sub-licensing clause (Section 2.2).
+
+Annex.2.2.Ti=Licence restrictions
+
+Clauses to be copy-pasted here include: obligations not to do or omit anything affecting the distinctiveness, validity or goodwill of the Trademark (Section 3.2), and not to use or register any confusing trademarks (Section 3.3).
+
+Annex.2.3.Ti=Intellectual property rights
+
+Clauses to be copy-pasted here include: stipulation of non-assignment and ownership (Section 8.1), accrual of usage to Licensor (Section 8.2) and ownership of copyrights in artwork (Section 8.3).
+
+Annex.2.4.Ti=Term and termination
+
+Clauses to be copy-pasted here include: a simplified Section 14.1 (regarding duration of the licence), the ordinary grounds for termination (Sections 14.2 and 14.4), as well as Licensor’s specific termination rights (Section 14.3), particularly if this includes change of control over Licensee, and if challenging the trademark is clearly not a violation of applicable competition laws, such termination right.
+
+
+Annex.3.Ti=Annex 3. Products and supporting services
+
+Annex.3.sec=[Insert a list of the products, (technical) product specifications and any supporting services required to be delivered by Licensee]
+
+Annex.4.Ti=Annex 4. Brand guidelines
+
+Annex.4.sec=[Insert the brand guidelines applicable to the Trademark used with the Products]
+
+ 
+


### PR DESCRIPTION
the Github client AS I’M DOING THE WORK.

Having comments here may not be the best place, but might be better
then in the files themselves, as I’ve done in past.

So:  notice that the Definitions are i) in the back and ii) mostly
cross-references to places in the document where the terms are defined.
 A few thoughts on that: — Definitions in the back seems like a good
idea to me even though it is common to put them in the front.
Definitions are - or should become sort of background or environmental
- part of what is assumed.  They should be relatively stable. On the
  other hand, this is in tension with another use of Definitions - which
  is as a kind of “parameter”.  E.g. “Seller will pay the Price.”  and
  “Price means $102.”   So, to be considered and worked out.  ii)
  embedding definitions in text is convenient for the drafter, but often
  less convenient for the reader, and less scalable.
