### PR TITLE
CabinetBondard - first cut at codifying Employ/Assign/

### DIFF
--- a/Doc/GH/CabinetBondard/FR/Form/Employ/Assign/0.md
+++ b/Doc/GH/CabinetBondard/FR/Form/Employ/Assign/0.md
@@ -1,0 +1,174 @@
+Note=Uses the party identification and the signature provisions from the "standard" French frame.  The originals are still in this file to permit comparison and correction as may be needed.
+
+FICHE DESCRIPTIVE : 
+
+1. INTITULE DU CONTRAT : « Contrat de cession de droits sur un logiciel - Entre un employeur et son salarié »
+
+2. REDIGE POUR :  Les deux parties, employeur et salarié
+
+3. PARTICULARITE : Contrat qui vient en plus du contrat de travail entre l’employeur et son salarié, contrat de travail à mettre en Annexe 1 du présent contrat. 
+
+4. DATE DE DERNIERE MODIFICATION : Le 05 septembre 2015 
+
+P1.=[U/id/acme_incorporated.md]
+
+P2.=[U/id/abigail_altima.md]
+
+=[zF/Agt/FR/Form/0.md]
+
+Frame.=[zF/Agt/FR/Frame/2Parties/0.md]  
+
+Doc.Ti=Contrat de cession de droits
+
+
+ENTRE LES SOUSSIGNES :
+
+Monsieur Indiquer le NOM et le prénom, demeurant Indiquer le domicile
+
+Ci-après « le Cédant », 
+
+d'une part,
+
+ET 
+
+Monsieur Indiquer le NOM et le prénom, demeurant Indiquer le domicile
+
+Ci-après « le Cessionnaire »,
+
+d'autre part,
+
+
+ETANT PREALABLEMENT RAPPELE QUE :
+
+Why.1.sec=Le Cessionnaire, porteur du projet nom du projet, a pour objectif de développer décrire le projet du cessionnaire
+
+Why.2.sec=Le Cessionnaire souhaite préparer indiquer le type de logiciel ou de plateforme pour nom du projet. 
+
+Why.3.sec=Décrire le type de logiciel ou de plateforme
+
+Why.4.sec=Le Cessionnaire a obtenu la labellisation indiquer si besoin. 
+
+Why.5.sec=Le Cédant prépare indiquer le type de logiciel ou de plateforme sous la direction du Cessionnaire.
+
+Why.6.sec=Dans ce cadre, le Cédant réalise un certain nombre de missions, notamment :
+
+Why.7.0.sec=Détailler les missions du cédant
+
+Why.7.1.sec=Le Cessionnaire souhaite être titulaire de l'ensemble des droits d'auteur sur la préparation du indiquer le type de logiciel ou de plateforme qui sera développée par le Cédant, et sur l’ensemble de la documentation qui sera rédigée par le Cédant. 
+
+Why.7.2.sec=C'est dans ce contexte que le Cédant et le Cessionnaire se sont rapprochés pour formaliser la cession des droits d'auteur portant sur la préparation du indiquer le type de logiciel ou de plateforme
+
+Why.7.=[Z/paras/s2]
+
+Why.=[Z/paras/s7]
+
+Why.=[Z/ol/s2]
+
+
+That.Ti=IL A ETE ENSUITE CONVENU ET ARRETE CE QUI SUIT : 
+
+1.Ti=Article 1. Objet du Contrat
+
+1.sec=Le Contrat a pour objet la cession par le Cédant au Cessionnaire de l'ensemble des droits patrimoniaux d'auteur relatifs à la création du indiquer le type de logiciel ou de plateforme. 
+
+2.Ti=Article 2. Cession des droits de propriété intellectuelle
+
+2.1.sec=Au titre du Contrat, le Cédant cède à titre exclusif et définitif au Cessionnaire, au fur et à mesure de la création du indiquer le type de logiciel ou de plateforme et des documents afférents rédigés pour son utilisation, l'ensemble des droits d'auteur y afférents ainsi que tout autre droit de propriété. 
+
+2.2.0.sec=Au titre de cette cession de droits, le Cédant cède notamment au Cessionnaire les droits :
+
+2.2.1.sec=•	de reproduction et d'utilisation pour quelque usage que ce soit, par quelque procédé que ce soit, sur tout support papier, magnétique, optique, vidéographique ou autre, pour toute exploitation, y compris en réseau ;
+
+2.2.2.sec=•	de représentation et diffusion, de quelque façon que ce soit, sur quelque support et/ou réseau que ce soit, édition ;
+
+2.2.3.sec=•	d'adaptation, de modification, correction, développement, intégration, transcription, traduction ;
+
+2.2.4.sec=•	de commercialisation, de quelque façon que ce soit.
+
+2.2.=[Z/paras/s4]
+
+2.3.sec=Cette cession est effective tant pour la France que pour l'étranger et pour toute la durée de protection du indiquer le type de logiciel ou de plateforme et des documents rédigés pour en permettre l’utilisation et l’exploitation par nom du projet.
+
+2.4.sec=A ce titre, le Cessionnaire pourra notamment, en toute indépendance, exploiter le indiquer le type de logiciel ou de plateforme et documents rédigés, ainsi que toute adaptation ou modification qu'il réaliserait, et notamment par voie de licences, à son seul profit et sans devoir de redevances au Cédant.
+
+2.5.sec=Aux termes de cette cession, le Cédant ne dispose plus d'aucun droit sur le indiquer le type de logiciel ou de plateforme et les documents rédigés.
+
+2.=[Z/ol/s5]
+
+3.Ti=Article 3. Livraison – Garantie
+
+3.1.0.sec=Le Cédant remettra au Cessionnaire, d’ici au indiquer une date sur support électronique (tel une clé USB),  l’univers du indiquer le type de logiciel ou de plateforme, sous la forme suivante : 
+
+A titre d’exemple :
+
+3.1.1.sec=•	les programmes d’installation standard des composants scientifiques,
+
+3.1.2.sec=•	les données produites,
+
+3.1.3.sec=•	les requêtes SQL de configuration ou d’extraction des données,
+
+3.1.4.sec=•	la documentation.
+
+3.1.=[Z/paras/s4]
+
+3.2.sec=Le Cédant garantit la conformité de la préparation indiquer le type de logiciel ou de plateforme à l’état de l’art scientifique communiqué par le Cessionnaire. 
+
+3.=[Z/ol/s2]
+
+4.Ti=Article 4. Prix
+
+4.sec=Le prix fixé par les parties pour la préparation du indiquer le type de logiciel ou de plateforme et des documents inclut le prix de cession des droits de propriété intellectuelle y afférents (Voir Annexe 1 au présent Contrat pour le Contrat de Travail signé entre le Cédant et le Cessionnaire). 
+
+5.Ti=Article 5. Propriété des Informations Communiquées
+
+5.1.0.sec=Le Cédant reconnaît avoir reçu du Cessionnaire toutes les informations et instructions relatives à la préparation du indiquer le type de logiciel ou de plateforme et à ses fonctionnalités, et notamment, mais pas exclusivement :
+
+A titre d’exemple :
+
+5.1.1.sec=état de l’art scientifique, algorithmes, spécifications d’environnement, mémoire de recherche sur les dérivations, informations sur les composants du simulateur, données techniques pour aider à la réalisation des tests de convenance, données de clients pilotes ou description des données à générer dans le simulateur Scientifique, schémas du procédé, description du processus et du dispositif technique, conditions d’exercice du savoir faire pour l’architecture scientifique. 
+
+5.1.=[Z/ol/s1]
+
+5.2.sec=Toute Information Confidentielle divulguée conformément au présent Contrat restera la propriété du Cessionnaire, et devra être retournée au Cessionnaire, à la demande de celui-ci, et en tout état de cause aux termes du Contrat figurant en Annexe 1 au présent Contrat (Contrat de Travail signé entre le Cédant et le Cessionnaire).  
+
+5.=[Z/ol/s2]
+
+6.Ti=Article 6. Confidentialité
+
+6.1.sec=Le Cédant s’engage à prendre toutes les précautions nécessaires pour maintenir la confidentialité des informations confidentielles transmises par le cessionnaire dans le cadre des présentes.
+
+6.2.sec=Le Cédant s’engage, pendant toute la durée du présent contrat et pendant un délai de cinq (5) ans à compter de la date de leur communication, à ne pas utiliser, communiquer, divulguer à un tiers ou exploiter, autrement que dans le cadre du présent Contrat, toute information ou connaissance de nature confidentielle qui lui aura été communiqué ou dont elle aura eu connaissance à l’occasion de l’exécution du présent Contrat, sauf autorisation écrite du Cessionnaire. 
+
+6.3.sec=Le Cédant s’engage à faire respecter les mêmes obligations de confidentialité de la part de ses conseillers et intervenants extérieurs. 
+
+6.4.sec=Le Cédant recevant une telle information qui l’utilise ou la divulgue en violation du présent accord, devra indemniser le Propriétaire pour toute perte ou dommage directs ou indirects en résultant. 
+
+6.5.sec=A l’expiration du présent contrat, le Cédant s’engage à restituer tous documents et matériels mis à sa disposition, tous dossiers et travaux qu’il aura élaboré dans le cadre de ses fonctions, ces éléments étant la propriété exclusive du Cessionnaire. 
+
+6.=[Z/ol/s5]
+
+7.Ti=Article 7. Loyauté 
+
+7.sec=Les parties s’engagent à toujours se comporter l’une envers l’autre comme des partenaires loyaux et de bonne foi, et notamment à signaler sans délai toute difficulté qu’elles pourraient rencontrer dans le cadre de l’exécution du présent Contrat. 
+
+8.Ti=Article 8. Droit applicable - Litiges 
+ 
+8.1.sec=Si des difficultés surviennent à l’occasion de l’interprétation ou de l’exécution ou de la terminaison du présent contrat, les parties auront recours à une conciliation amiable préalablement à toute instance judiciaire. 
+
+8.2.sec=Si les difficultés survenues à l’occasion de l’interprétation ou de l’exécution ou de la terminaison du présent contrat n’ont pas été résolues par voie de conciliation, le litige sera soumis aux juridictions indiquer les juridictions compétentes (exemple : françaises) compétentes qui le trancheront conformément à la loi déterminer la loi applicable au Contrat.
+
+8.=[Z/ol/s2]
+
+=[Z/ol-none/8]
+
+Fait à lieu de conclusion du Contrat, le date
+
+En 2 exemplaires originaux.
+
+Le Cédant
+Nom du cédant
+
+
+
+Le Cessionnaire
+Nom du cessionnaire


### PR DESCRIPTION
The notion is to organize them by subject.  The names used are in English, which is certainly controversial, perhaps shocking, and needs discussion/debate.  The reason for English is to make it possible to have a compatible naming systems across all jurisdictions and languages.  That will make for easy comparison, cross-pollination, convergence of subject matter.  See, for instance some of the work done on EU "Model Clauses" and the like.  
The names themselves also are subject to discussion.   They are my best attempt.  They attempt to be pithy.  It still feels like there are inconsistencies.  But it's a start.